### PR TITLE
Various updates

### DIFF
--- a/autoframework
+++ b/autoframework
@@ -53,8 +53,7 @@ for ARCH in $ARCHS; do
 done
 
 # Install header files
-PREFIX="$STATICDIR/$ARCH" $ICONFIGURE $ARCH --includedir="$FRAMEWORKDIR/Headers" $@
-make
+PKG_CONFIG_DIR="$PKG_CONFIG_DIR":"$STATICDIR/lib/pkgconfig" PREFIX="$STATICDIR/$ARCH" $ICONFIGURE $ARCH --includedir="$FRAMEWORKDIR/Headers" $@
 make install
 
 # Create multiarch archive

--- a/autoframework
+++ b/autoframework
@@ -10,6 +10,7 @@ usage () {
   echo "    ARCHS     Only build for specific architectures. Default is:"
   echo "                armv7|armv7s|arm64|i686|x86_64"
   echo "    PREFIX    Installation prefix for framework and static files."
+  echo "    SUFFIX    Suffix for static directory (pass in CONFIGURATION, etc)."
   echo ""
   echo "  All additional parameters are passed to the configure script."
   exit 1
@@ -31,7 +32,12 @@ if [ -z "$PREFIX" ]; then
   PREFIX="$(pwd)"
 fi
 
-STATICDIR="$PREFIX/Static"
+if [ -z "$SUFFIX" ]; then
+  STATICDIR="$PREFIX/Static"
+else
+  STATICDIR="$PREFIX/Static/$SUFFIX"
+fi
+
 FRAMEWORKDIR="$PREFIX/Frameworks/$FRAMEWORK.framework"
 
 if [ -z "$ARCHS" ]; then

--- a/iconfigure
+++ b/iconfigure
@@ -102,6 +102,9 @@ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH":"$SDKROOT/usr/lib/pkgconfig":"$PREFIX/
 # Remove script parameters
 shift 1
 
+export ac_cv_func_malloc_0_nonnull=yes
+export ac_cv_func_realloc_0_nonnull=yes
+
 # Run configure
 ./configure \
 	--prefix="$PREFIX" \

--- a/iconfigure
+++ b/iconfigure
@@ -7,7 +7,8 @@ usage () {
   echo "  architecture   Target architecture. [armv7|armv7s|arm64|i386|x86_64]"
   echo ""
   echo "  VARIABLEs are:"
-  echo "    SDKVERSION   Target a specific SDK version."
+  echo "    SDKVERSION   SDK version to use for compilation."
+  echo "    SDKTARGET    Target a specific SDK version."
   echo "    PREFIX       Custom install prefix, useful for local installs."
   echo "    CHOST        Configure host, set if not deducable by ARCH."
   echo "    SDK          SDK target, set if not deducable by ARCH. [iphoneos|iphonesimulator]"
@@ -79,6 +80,13 @@ else
   export SDKROOT=$(xcrun --sdk $SDK --show-sdk-path) # current version
 fi
 
+# Export supplied SDKTARGET or use SDKVERSION
+if [ ! -z "$SDKTARGET" ]; then
+  export SDKTARGET
+else
+  export SDKTARGET=$SDKVERSION
+fi
+
 # Export supplied PREFIX or use default
 if [ ! -z "$PREFIX" ]; then
   export PREFIX
@@ -93,8 +101,8 @@ export CXX=$(xcrun --sdk $SDK --find g++)
 export LD=$(xcrun --sdk $SDK --find ld)
 
 # Flags
-export CFLAGS="$CFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION -fembed-bitcode"
-export CPPFLAGS="$CPPFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION -fembed-bitcode"
+export CFLAGS="$CFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKTARGET -fembed-bitcode"
+export CPPFLAGS="$CPPFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKTARGET -fembed-bitcode"
 export CXXFLAGS="$CXXFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -fembed-bitcode"
 export LDFLAGS="$LDFLAGS -arch $ARCH -isysroot $SDKROOT -L$PREFIX/lib"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH":"$SDKROOT/usr/lib/pkgconfig":"$PREFIX/lib/pkgconfig"

--- a/iconfigure
+++ b/iconfigure
@@ -109,6 +109,7 @@ export ac_cv_func_realloc_0_nonnull=yes
 ./configure \
 	--prefix="$PREFIX" \
 	--host="$CHOST" \
+	--with-sysroot="$SDKROOT" \
 	--enable-static \
 	--disable-shared \
 	$@

--- a/iconfigure
+++ b/iconfigure
@@ -80,13 +80,6 @@ else
   export SDKROOT=$(xcrun --sdk $SDK --show-sdk-path) # current version
 fi
 
-# Export supplied SDKTARGET or use SDKVERSION
-if [ ! -z "$SDKTARGET" ]; then
-  export SDKTARGET
-else
-  export SDKTARGET=$SDKVERSION
-fi
-
 # Export supplied PREFIX or use default
 if [ ! -z "$PREFIX" ]; then
   export PREFIX
@@ -114,10 +107,10 @@ export ac_cv_func_malloc_0_nonnull=yes
 export ac_cv_func_realloc_0_nonnull=yes
 
 # Run configure
+	#--with-sysroot="$SDKROOT" \
 ./configure \
 	--prefix="$PREFIX" \
 	--host="$CHOST" \
-	--with-sysroot="$SDKROOT" \
 	--enable-static \
 	--disable-shared \
 	$@

--- a/iconfigure
+++ b/iconfigure
@@ -93,9 +93,9 @@ export CXX=$(xcrun --sdk $SDK --find g++)
 export LD=$(xcrun --sdk $SDK --find ld)
 
 # Flags
-export CFLAGS="$CFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION"
-export CPPFLAGS="$CPPFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION"
-export CXXFLAGS="$CXXFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include"
+export CFLAGS="$CFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION -fembed-bitcode"
+export CPPFLAGS="$CPPFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -miphoneos-version-min=$SDKVERSION -fembed-bitcode"
+export CXXFLAGS="$CXXFLAGS -arch $ARCH -isysroot $SDKROOT -I$PREFIX/include -fembed-bitcode"
 export LDFLAGS="$LDFLAGS -arch $ARCH -isysroot $SDKROOT -L$PREFIX/lib"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH":"$SDKROOT/usr/lib/pkgconfig":"$PREFIX/lib/pkgconfig"
 


### PR DESCRIPTION
Hey there,

I've added a few things. One adds the `-fbitcode` flag for better compat in the Swift era, a couple of exports to workaround `autoconf` being stupid with C++ code and not properly detecting `malloc` support and wrecking up the place, and finally, adding `--with-sysroot` to `./configure` to be extra sure that the sysroot is set. Some scripts need it because they do bizarre things with the knowledge that a `CFLAGS` won't solve.
